### PR TITLE
Initialize ginger without use enter nor show error - fix

### DIFF
--- a/route.js
+++ b/route.js
@@ -299,7 +299,7 @@ Request.prototype.exec = function(prevs){
     node.render && node.render(self);
 
     node.enter && node.enter(self);
-    node.enter || node.show(self);
+    node.enter || (node.show && node.show(self));
     
     node.after && node.after(self);
   }


### PR DESCRIPTION
I fixed small error in ginger route. It assumes that one of func: node.enter or node.show are always available. When I don't use them it caused runtime error that there is no method 'show'. I think I fixed it, please review.
